### PR TITLE
DALI Zarr example but via `DALIGenericIterator` 

### DIFF
--- a/test_case/ERA5TimeSeriesDataset.py
+++ b/test_case/ERA5TimeSeriesDataset.py
@@ -9,6 +9,9 @@ import os
 import xarray as xr
 import torch
 from torch.utils.data import Dataset, DataLoader
+import numpy as np
+
+
 
 class ERA5Dataset:
     """
@@ -88,6 +91,21 @@ class ERA5Dataset:
         x_data = self.ds_x.isel(time=index).to_array().values
         y_data = self.ds_y.isel(time=index).to_array().values
         return (x_data, y_data)
+
+    def __iter__(self):
+        """Reset index for new iteration"""
+        self.index = 0
+        return self
+
+    def __next__(self):
+        """Return (input, target) pair with proper forecast offset"""
+        if self.index < self.length:
+            # Get input and target at current index
+            x_data = self.ds_x.isel(time=self.index).to_array().values
+            y_data = self.ds_y.isel(time=self.index).to_array().values
+            self.index += 1
+            return (x_data, y_data)
+        raise StopIteration
  
 
 
@@ -128,6 +146,73 @@ class PyTorchERA5Dataset(Dataset):
 
         return x_tensor, y_tensor
 
+# ---------------------------
+# NVIDIA DALI Pipeline
+# ---------------------------
+from nvidia.dali.pipeline import pipeline_def
+import nvidia.dali.fn as fn
+import nvidia.dali.types as types
+from nvidia.dali.plugin.pytorch import DALIGenericIterator
+@pipeline_def
+def dali_era5_pipeline(input_data):
+    """
+    NVIDIA DALI pipeline for processing ERA5 dataset.
+
+    Args:
+        input_data: ERA5 dataset (NumPy arrays)
+
+    Returns:
+        Processed tensors for model training
+    """
+
+    # Load external source (ERA5 Data)
+    input_data, target_data = fn.external_source(source=input_data, batch=True, num_outputs=2, dtype=types.FLOAT)
+    
+
+    return input_data, target_data
+
+
+# ---------------------------
+# DALI Iterator Class
+# ---------------------------
+
+class ERA5DALIDataLoader:
+    """
+    # From ExternalInputIterator
+    DALI-based DataLoader for handling dataset efficiently.
+    """
+
+    def __init__(self, dataset, batch_size=8, num_threads=4, device_id=0):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.num_threads = num_threads
+        self.device_id = device_id
+        self.index = 0
+
+    def __call__(self):
+        """
+        Generator function that provides batches of ERA5 data.
+        """
+        batch_x = []
+        batch_y = []
+
+        for _ in range(self.batch_size):
+            if self.index >= len(self.dataset):
+                self.index = 0  # Reset index if exceeding dataset length
+
+            # This uses the __getitem__ method of the ERA5Dataset class
+            x_data, y_data = self.dataset[self.index]
+            batch_x.append(x_data)
+            batch_y.append(y_data)
+            #print (f"Batch {self.index}: {x_data.shape}, {y_data.shape}")   
+
+            self.index += 1
+
+        return np.stack(batch_x, axis=0), np.stack(batch_y, axis=0)
+    
+    def __repr__(self):
+        return f"ERA5DALIDataLoader(batch_size={self.batch_size}, num_threads={self.num_threads}, device_id={self.device_id})"
+
 
 
 if __name__ == "__main__":
@@ -139,11 +224,28 @@ if __name__ == "__main__":
     input_vars = ['t2m', 'V500', 'U500', 'T500', 'Z500', 'Q500']
 
     train_dataset = ERA5Dataset(data_path, start_year, end_year, input_vars=input_vars)
+
+
+
     print (train_dataset)
     forecast_step = 1
     ds_x , ds_y = train_dataset.fetch_timeseries(forecast_step=1)
 
     print(ds_x)
+    batch_size = 16
+    print (ERA5DALIDataLoader(train_dataset, batch_size=batch_size))
+    print ('***')
+    pipeline = dali_era5_pipeline(batch_size=batch_size, num_threads=4, device_id=0, input_data=ERA5DALIDataLoader(train_dataset, batch_size=batch_size))
+
+    # Create DALI PyTorch Iterator
+    dali_loader = DALIGenericIterator(pipelines=[pipeline], output_map=["input", "target"], size=len(train_dataset), auto_reset=True)
+
+    for i, data in enumerate(dali_loader):
+        input_batch, target_batch = data[0]["input"], data[0]["target"]
+        print(f"Batch {i+1}: Input shape {input_batch.shape}, Target shape {target_batch.shape}")
+    # Alternatively, you can use the PyTorchERA5Dataset class directly:
+
+
 
     # or use with data loader for pytorch as follows:
     # pytorch_dataset = PyTorchERA5Dataset(train_dataset)


### PR DESCRIPTION
This worked!  But there should be things that are wrong with it since RMSE looks wrong (very wrong). 

```
python ERA5TimeSeriesDataset.py
```

or 

```
python train_unet.py
```

This is replacing the pytorch data loader and does not work with multi-gpu. 