### PR TITLE
Start adapting Modulus SeqZarrSource class to ERA5 dataset on Derecho

### DIFF
--- a/test_case/ERA5TimeSeriesDataset.py
+++ b/test_case/ERA5TimeSeriesDataset.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
             num_threads=4,
             prefetch_queue_depth=4,
             py_num_workers=4,
-            device_id=torch.device("cuda:0"),
+            device_id=0,
             py_start_method="fork",
         )
         with pipe:
@@ -301,4 +301,5 @@ if __name__ == "__main__":
             pipe.set_outputs(*data)
 
         pipe.build()
-        arr = pipe.run()
+        arrays = pipe.run()
+        print(arrays)

--- a/test_case/ERA5TimeSeriesDataset.py
+++ b/test_case/ERA5TimeSeriesDataset.py
@@ -232,14 +232,25 @@ class SeqZarrSource:
                     batch_data, (self.batch_size, self.num_steps, *batch_data.shape[1:])
                 )
             )
+        # assert len(data) == 6
+        # assert data[0].shape == (1, 2, 640, 1280)  # BTHW
 
-        return tuple(data)
+        # Stack variables along channel dimension, and split into two along timestep dim
+        data_stack = np.stack(data, axis=2)
+        # assert data_stack.shape == (1, 2, 6, 640, 1280)  # BTCHW
+        data_x = data_stack[:, 0, :, :, :]
+        # assert data_x.shape == (1, 6, 640, 1280)  # BCHW
+        data_y = data_stack[:, 1, :, :, :]
+        # assert data_y.shape == (1, 6, 640, 1280)  # BCHW
+
+        return (data_x, data_y)
 
     def __len__(self):
         if self.batch:
             return self.batch_mapping.shape[0] * self.batch_size
         else:
             return len(self.indices)
+
 
 
 # %%
@@ -286,7 +297,7 @@ if __name__ == "__main__":
             # Read current batch
             data = dali.fn.external_source(
                 source,
-                num_outputs=6,  # len(self.pipe_outputs),
+                num_outputs=2,  # len(self.pipe_outputs),
                 parallel=True,
                 batch=True,
                 prefetch_queue_depth=4,

--- a/test_case/ERA5TimeSeriesDataset.py
+++ b/test_case/ERA5TimeSeriesDataset.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
             num_threads=4,
             prefetch_queue_depth=4,
             py_num_workers=4,
-            device_id=None,
+            device_id=torch.device("cuda:0"),
             py_start_method="fork",
         )
         with pipe:

--- a/test_case/ERA5TimeSeriesDataset.py
+++ b/test_case/ERA5TimeSeriesDataset.py
@@ -259,7 +259,7 @@ class SeqZarrSource:
     prefetch_queue_depth=4,
     py_num_workers=4,
     device_id=0,
-    py_start_method="fork",
+    py_start_method="spawn",
 )
 def seqzarr_pipeline():
     """


### PR DESCRIPTION
Alternative to #11, adapted from https://github.com/NVIDIA/modulus/blob/v0.9.0/examples/weather/unified_recipe/seq_zarr_datapipe.py#L186 based on suggestions from @akshaysubr

Current limitations:
- Only reading one Zarr store instead of many Zarr stores (can be fixed either by concatenating all Zarr stores into one, or wait for further improvements on xarray/zarr-python)
- Multiple Zarr get calls per variable, instead of a single Zarr call to many variables (workaround is to concatenate multiple variables into a single 'channel' within the Zarr store, at the expense of a less readable Zarr store).